### PR TITLE
convert time to UTC to comply with proper specific time zone

### DIFF
--- a/lib/fluent/plugin/out_mail.rb
+++ b/lib/fluent/plugin/out_mail.rb
@@ -164,7 +164,7 @@ class Fluent::MailOutput < Fluent::Output
     body = msg.force_encoding('binary')
 
     smtp.send_mail(<<EOS, @from, @to.split(/,/), @cc.split(/,/), @bcc.split(/,/))
-Date: #{Time.now.utc.strftime("%a, %d %b %Y %X %z")}
+Date: #{Time::now.utc.strftime("%a, %d %b %Y %X %z")}
 From: #{@from}
 To: #{@to}
 Cc: #{@cc}


### PR DESCRIPTION
Dear u-ichi san

I might be wrong but anyways, I found a little thingie about the time of the mails that are sent using fluent-plugin-mail. The "hour" in which those mails were sent was simply not correct. I thought that my server (CentOS) was wrong but maybe the time is not properly changed to UTC. Per  ruby-doc.org/core-2.0/Time.html#method-i-strftime Time::now merely returns a time object initialized to the current system time, but we may need to give it UTC shape for emails, so I added the change. It worked well on CentOS. Regards, 

Adrian
