### PR TITLE
add mail-header config and add mode to send all log message

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,35 @@ Email is sent like
     pattern: #{pattern}
     value: #{value}
 
+## Mail Configuration with message_out_record
+
+    <match **>
+      type mail
+      host SMTPSERVER
+      port 25
+      from SOURCE
+      to DEST1,DEST2,DEST3
+      subject SUBJECT: %s
+      subject_out_keys target_tag
+      message MESSAGE BODY: %s
+      message_out_record true
+      message_size_limit -1 #no limit
+      time_locale UTC # optional
+      reply_to sample@example.com
+      return_path sample@example.com
+      auth_type cram_md5
+    </match>
+
+Email is sent like
+
+    From: SOURCE
+    To: DEST1,DEST2,DEST3
+    Subject: SUBJECT: #{target_tag}
+    Mime-Version: 1.0
+    Content-Type: text/plain; charset=utf-8
+
+    MESSAGE BODY: #{log record}
+
 ## Mail Configuration with Message Format (no auth)
 
 You may use `message` parameter to define mail format as you like. Use `\n` to put a return code.

--- a/test/plugin/test_out_mail.rb
+++ b/test/plugin/test_out_mail.rb
@@ -43,7 +43,26 @@ class MailOutputTest < Test::Unit::TestCase
     to localhost@localdomain
   ]
 
-  def create_driver(conf=CONFIG_OUT_KEYS,tag='test')
+  CONFIG_RECORD_MESSAGE = %[
+    message out_mail: record message %s
+    message_out_record true
+    time_key time
+    time_format %Y/%m/%d %H:%M:%S
+    tag_key tag
+    subject Fluentd Notification Alarm %s
+    subject_out_keys tag
+    host localhost
+    port 25
+    from localhost@localdomain
+    to localhost@localdomain
+    reply_to reply-mail@example.com
+    return_path rerurn-mail@example.com
+    auth_type cram_md5
+  ]
+
+
+ eodef create_driver(cenf=CONFIG_OUT_KEYS,tag='test')
+ eodef create_driver(conf=CONFIG_OUT_KEYS,tag='test')
     Fluent::Test::OutputTestDriver.new(Fluent::MailOutput, tag).configure(conf)
   end
 
@@ -53,6 +72,8 @@ class MailOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG_CC_BCC)
     assert_equal 'localhost', d.instance.host
     d = create_driver(CONFIG_MESSAGE)
+    assert_equal 'localhost', d.instance.host
+    d = create_driver(CONFIG_RECORD_MESSAGE)
     assert_equal 'localhost', d.instance.host
   end
 
@@ -72,5 +93,12 @@ class MailOutputTest < Test::Unit::TestCase
     end
   end
 
+  def test_out_record
+    d = create_driver(CONFIG_RECORD_MESSAGE)
+    time = Time.now.to_i
+    d.run do
+      d.emit({'value' => "message mail from fluentd out_mail"}, time )
+    end
+  end
 end
 


### PR DESCRIPTION
I added mail_header config and new message sending mode for fluent-plugin-mail.
- mail_header config
  *\* reply_to
  *\* return_path
  *\* auth_type
- message sending mode is  all log message sending.

p.s. I'm no good at English. so. My English is wrong...maybe. 
