### PR TITLE
fix test for 0.12.0.pre.1

### DIFF
--- a/test/plugin/test_out_mail.rb
+++ b/test/plugin/test_out_mail.rb
@@ -1,6 +1,9 @@
 require 'helper'
 
 class MailOutputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
 
   CONFIG_OUT_KEYS = %[
     out_keys tag,time,value


### PR DESCRIPTION
Running test with fluentd v0.12.0.pre.1 results in error as followings:

```
MailOutputTest#test_configure:
NoMethodError: undefined method `event_router' for nil:NilClass
    /home/travis/.rvm/gems/ruby-2.1.3/bundler/gems/fluentd-92e54b03de5a/lib/fluent/test/base.rb:34:in `initialize'
    /home/travis/.rvm/gems/ruby-2.1.3/bundler/gems/fluentd-92e54b03de5a/lib/fluent/test/input_test.rb:28:in `initialize'
```

This pull request fixes it. Still works with v0.10.x, too. 
