### PR TITLE
fix gemspec

### DIFF
--- a/fluent-plugin-mail.gemspec
+++ b/fluent-plugin-mail.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-mail"
   gem.require_paths = ["lib"]
   gem.version       = '0.0.5'
-  gem.add_development_dependency "fluentd"
   gem.add_development_dependency "rake"
   gem.add_runtime_dependency "fluentd"
 end


### PR DESCRIPTION
Fix warning

```
fluent-plugin-mail at /home/game/src/github.com/u-ichi/fluent-plugin-mail did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on fluentd (>= 0), (>= 0) use:
    add_runtime_dependency 'fluentd', '>= 0', '>= 0'
```
