### PR TITLE
string-scrub

### DIFF
--- a/fluent-plugin-mail.gemspec
+++ b/fluent-plugin-mail.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-mail"
   gem.require_paths = ["lib"]
   gem.version       = '0.1.0'
-  gem.add_development_dependency "rake"
+
   gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "string-scrub" if RUBY_VERSION.to_f < 2.1
+  gem.add_development_dependency "rake"
 end

--- a/test/plugin/test_out_mail.rb
+++ b/test/plugin/test_out_mail.rb
@@ -75,5 +75,13 @@ class MailOutputTest < Test::Unit::TestCase
     end
   end
 
+  def test_with_scrub
+    d = create_driver(CONFIG_MESSAGE)
+    invalid_string = "\xff".force_encoding('UTF-8')
+    assert_nothing_raised {
+      res = d.instance.with_scrub(invalid_string) {|str| str.gsub(/\\n/, "\n") }
+      assert_equal '?', res
+    }
+  end
 end
 


### PR DESCRIPTION
I got an error like

```
ArgumentError invalid byte sequence in UTF-8 out_mail.rb:142:in `gsub'
```

This patch avoids the above error by replacing the invalid byte string to `?`. 
This is doing almost same thing with fluent-plugin-grep https://github.com/sonots/fluent-plugin-grep. 