### PR TITLE
Add a secret parameter

### DIFF
--- a/lib/fluent/plugin/out_mail.rb
+++ b/lib/fluent/plugin/out_mail.rb
@@ -17,7 +17,7 @@ class Fluent::MailOutput < Fluent::Output
   config_param :port,                 :integer, :default => 25
   config_param :domain,               :string,  :default => 'localdomain'
   config_param :user,                 :string,  :default => nil
-  config_param :password,             :string,  :default => nil
+  config_param :password,             :string,  :default => nil, :secret => true
   config_param :from,                 :string,  :default => 'localhost@localdomain'
   config_param :to,                   :string,  :default => ''
   config_param :cc,                   :string,  :default => ''


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
https://github.com/fluent/fluentd/blob/4e3a4ecb/ChangeLog#L34

This feature works as below:

```log
  <match **>
    type mail
    host smtp.gmail.com
    port 587
    domain gmail.com
    from SOURCE
    to DEST1,DEST2,DEST3
    subject SUBJECT
    user USERNAME( ex. hoge@gmail.com)
    password xxxxxx
    enable_starttls_auto true
    enable_tls false
    out_keys tag,foo,message
    time_locale UTC
  </match>
</ROOT>
```