### PR TITLE
Use array type for array like parameters

### DIFF
--- a/fluent-plugin-mail.gemspec
+++ b/fluent-plugin-mail.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = '0.2.4'
   gem.license       = "Apache-2.0"
 
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", '>= 0.10.46'
   gem.add_runtime_dependency "string-scrub" if RUBY_VERSION.to_f < 2.1
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit"

--- a/lib/fluent/plugin/out_mail.rb
+++ b/lib/fluent/plugin/out_mail.rb
@@ -17,11 +17,11 @@ class Fluent::MailOutput < Fluent::Output
   end
 
   desc "Output comma delimited keys"
-  config_param :out_keys,             :string,  :default => ""
+  config_param :out_keys,             :array,  :default => []
   desc "Format string to construct message body"
   config_param :message,              :string,  :default => nil
   desc "Specify comma delimited keys output to `message`"
-  config_param :message_out_keys,     :string,  :default => ""
+  config_param :message_out_keys,     :array,  :default => []
   desc "Identify the timestamp of the record"
   config_param :time_key,             :string,  :default => nil
   desc "Identify the tag of the record"
@@ -53,7 +53,7 @@ class Fluent::MailOutput < Fluent::Output
   desc "Format string to construct mail subject"
   config_param :subject,              :string,  :default => 'Fluent::MailOutput plugin'
   desc "Specify comma delimited keys output to `subject`"
-  config_param :subject_out_keys,     :string,  :default => ""
+  config_param :subject_out_keys,     :array,  :default => []
   desc "If set to true, enable STARTTLS"
   config_param :enable_starttls_auto, :bool,    :default => false
   desc "If set to true, enable TLS"
@@ -75,10 +75,6 @@ class Fluent::MailOutput < Fluent::Output
 
   def configure(conf)
     super
-
-    @out_keys = @out_keys.split(',')
-    @message_out_keys = @message_out_keys.split(',')
-    @subject_out_keys = @subject_out_keys.split(',')
 
     if @out_keys.empty? and @message.nil?
       raise Fluent::ConfigError, "Either 'message' or 'out_keys' must be specifed."

--- a/test/plugin/test_out_mail.rb
+++ b/test/plugin/test_out_mail.rb
@@ -60,6 +60,19 @@ class MailOutputTest < Test::Unit::TestCase
     cc_key cc
     bcc_key bcc
   ]
+  CONFIG_KEYS_WITH_WHITESPACES = %[
+    out_keys tag,time, value
+    time_key time
+    time_format %Y/%m/%d %H:%M:%S
+    tag_key tag
+    message_out_keys msg, log_level
+    subject Fluentd Notification Alarm %s
+    subject_out_keys tag, content_id
+    host localhost
+    port 25
+    from localhost@localdomain
+    to localhost@localdomain
+  ]
 
   def create_driver(conf=CONFIG_OUT_KEYS,tag='test')
     Fluent::Test::OutputTestDriver.new(Fluent::MailOutput, tag).configure(conf)
@@ -68,10 +81,18 @@ class MailOutputTest < Test::Unit::TestCase
   def test_configure
     d = create_driver(CONFIG_OUT_KEYS)
     assert_equal 'localhost', d.instance.host
+    assert_equal ['tag', 'time', 'value'], d.instance.out_keys
     d = create_driver(CONFIG_CC_BCC)
     assert_equal 'localhost', d.instance.host
+    assert_equal ['tag', 'time', 'value'], d.instance.out_keys
     d = create_driver(CONFIG_MESSAGE)
     assert_equal 'localhost', d.instance.host
+    assert_equal ['tag', 'time', 'value'], d.instance.message_out_keys
+    d = create_driver(CONFIG_KEYS_WITH_WHITESPACES)
+    assert_equal 'localhost', d.instance.host
+    assert_equal ['tag', 'time', 'value'], d.instance.out_keys
+    assert_equal ['tag', 'content_id'], d.instance.subject_out_keys
+    assert_equal ['msg', 'log_level'], d.instance.message_out_keys
   end
 
   def test_out_keys


### PR DESCRIPTION
I tried to use array type instead of string with `#split` method.

Because traditional splitting way makes some pitfail:

```
message_out_keys id,name,age
```

and

```
message_out_keys id, name, age
```

is not equal.

Formater is interpreted as `['id', 'name', 'age']`.
But latter is `['id', ' name', ' age']`.