### PR TITLE
Use whitespace considered split method

### DIFF
--- a/lib/fluent/plugin/out_mail.rb
+++ b/lib/fluent/plugin/out_mail.rb
@@ -76,9 +76,9 @@ class Fluent::MailOutput < Fluent::Output
   def configure(conf)
     super
 
-    @out_keys = @out_keys.split(',')
-    @message_out_keys = @message_out_keys.split(',')
-    @subject_out_keys = @subject_out_keys.split(',')
+    @out_keys = @out_keys.split(/\s*,\s*/)
+    @message_out_keys = @message_out_keys.split(/\s*,\s*/)
+    @subject_out_keys = @subject_out_keys.split(/\s*,\s*/)
 
     if @out_keys.empty? and @message.nil?
       raise Fluent::ConfigError, "Either 'message' or 'out_keys' must be specifed."

--- a/test/plugin/test_out_mail.rb
+++ b/test/plugin/test_out_mail.rb
@@ -60,6 +60,19 @@ class MailOutputTest < Test::Unit::TestCase
     cc_key cc
     bcc_key bcc
   ]
+  CONFIG_KEYS_WITH_WHITESPACES = %[
+    out_keys tag,time, value
+    time_key time
+    time_format %Y/%m/%d %H:%M:%S
+    tag_key tag
+    message_out_keys msg, log_level
+    subject Fluentd Notification Alarm %s
+    subject_out_keys tag, content_id
+    host localhost
+    port 25
+    from localhost@localdomain
+    to localhost@localdomain
+  ]
 
   def create_driver(conf=CONFIG_OUT_KEYS,tag='test')
     Fluent::Test::OutputTestDriver.new(Fluent::MailOutput, tag).configure(conf)
@@ -68,10 +81,18 @@ class MailOutputTest < Test::Unit::TestCase
   def test_configure
     d = create_driver(CONFIG_OUT_KEYS)
     assert_equal 'localhost', d.instance.host
+    assert_equal ['tag', 'time', 'value'], d.instance.out_keys
     d = create_driver(CONFIG_CC_BCC)
     assert_equal 'localhost', d.instance.host
+    assert_equal ['tag', 'time', 'value'], d.instance.out_keys
     d = create_driver(CONFIG_MESSAGE)
     assert_equal 'localhost', d.instance.host
+    assert_equal ['tag', 'time', 'value'], d.instance.message_out_keys
+    d = create_driver(CONFIG_KEYS_WITH_WHITESPACES)
+    assert_equal 'localhost', d.instance.host
+    assert_equal ['tag', 'time', 'value'], d.instance.out_keys
+    assert_equal ['tag', 'content_id'], d.instance.subject_out_keys
+    assert_equal ['msg', 'log_level'], d.instance.message_out_keys
   end
 
   def test_out_keys


### PR DESCRIPTION
This is an another approach of #38.
But I dislike this approach because v0.10 is already EOL and fluentd plugin should be encouraged to use convenient method to prevent making a pitfall.

---

Because non-regexp splitting way makes some pitfail:

```
message_out_keys id,name,age
```

and

```
message_out_keys id, name, age
```

is not equal.

Formater is interpreted as ['id', 'name', 'age'].
But latter is ['id', ' name', ' age'].