### PR TITLE
Support for mustache templates as message body

### DIFF
--- a/example/sample_template.mustache
+++ b/example/sample_template.mustache
@@ -1,0 +1,3 @@
+<b>Hello</b> from out_mail!
+
+Message was: {{message}} at {{time}}!

--- a/example/template.conf
+++ b/example/template.conf
@@ -1,0 +1,23 @@
+# echo '{"message":"This is a test","bcc":"bcc@example.com"}' | bundle exec fluent-cat mail.test
+
+<source>
+  @type forward
+</source>
+
+<match mail.test>
+  @type mail
+  @log_level debug
+  host localhost
+  port 1025
+  from from@example.com
+  to   to@example.com
+  to_key to
+  bcc_key bcc
+  subject this is a test
+  message_template_file example/sample_template.mustache
+  time_key time
+  time_locale Asia/Taipei
+  # localtime false
+  time_format %Y-%m-%d %H:%M:%S %z
+  content_type text/html
+</match>

--- a/fluent-plugin-mail.gemspec
+++ b/fluent-plugin-mail.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "fluentd", '>= 0.12.0'
   gem.add_runtime_dependency "string-scrub" if RUBY_VERSION.to_f < 2.1
+  gem.add_runtime_dependency "mustache", '~> 1.0'
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit"
 end

--- a/test/plugin/test_out_mail.rb
+++ b/test/plugin/test_out_mail.rb
@@ -73,6 +73,17 @@ class MailOutputTest < Test::Unit::TestCase
     from localhost@localdomain
     to localhost@localdomain
   ]
+  CONFIG_MESSAGE_TEMPLATE = %[
+    time_key time
+    time_format %Y/%m/%d %H:%M:%S
+    subject Fluentd Notification Alarm %s
+    subject_out_keys tag, content_id
+    host localhost
+    port 25
+    from localhost@localdomain
+    to localhost@localdomain
+    message_template_file #{File.dirname(__FILE__)}/test_template.mustache
+  ]
 
   def create_driver(conf=CONFIG_OUT_KEYS,tag='test')
     Fluent::Test::OutputTestDriver.new(Fluent::MailOutput, tag).configure(conf)
@@ -93,6 +104,8 @@ class MailOutputTest < Test::Unit::TestCase
     assert_equal ['tag', 'time', 'value'], d.instance.out_keys
     assert_equal ['tag', 'content_id'], d.instance.subject_out_keys
     assert_equal ['msg', 'log_level'], d.instance.message_out_keys
+    d = create_driver(CONFIG_MESSAGE_TEMPLATE)
+    assert_true d.instance.message_template_file.end_with?('test_template.mustache')
   end
 
   def test_out_keys
@@ -132,6 +145,14 @@ class MailOutputTest < Test::Unit::TestCase
       res = d.instance.with_scrub(invalid_string) {|str| str.gsub(/\\n/, "\n") }
       assert_equal '?', res
     }
+  end
+
+  def test_with_template
+    d = create_driver(CONFIG_MESSAGE_TEMPLATE)
+    time = Time.now.to_i
+    d.run do
+      d.emit({'value' => "message mail from fluentd out_mail"}, time)
+    end
   end
 end
 

--- a/test/plugin/test_template.mustache
+++ b/test/plugin/test_template.mustache
@@ -1,0 +1,1 @@
+The message was: {{message}}


### PR DESCRIPTION
This PR adds support for using [Mustache](https://mustache.github.io/) templates for defining the message body. Available template variables are the contents of the respective record.

The goal is to support more complex mails with a lot of variables, which are difficult to construct using the current `%s` formatting option.