### PR TITLE
Add config param to support additional, custom mail headers

### DIFF
--- a/example/example.conf
+++ b/example/example.conf
@@ -19,4 +19,5 @@
   time_locale Asia/Taipei
   # localtime false
   time_format %Y-%m-%d %H:%M:%S %z
+  additional_headers {"X-Priority": "1", "X-Mailer": "fluentd"}
 </match>


### PR DESCRIPTION
This PR adds support to pass custom mail headers, e.g. a certain message priority, to the mail message sent.